### PR TITLE
Remove link relation text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Network Working Group                                          W. Kumari
 Internet-Draft                                                    Google
-Updates: 7710 (if approved)                                     E. Kline
+Obsoletes: 7710 (if approved)                                   E. Kline
 Intended status: Standards Track                                    Loon
-Expires: January 3, 2020                                    July 2, 2019
+Expires: January 2, 2020                                       July 2019
 
 
                Captive-Portal Identification in DHCP / RA
@@ -43,19 +43,19 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 3, 2020.
+   This Internet-Draft will expire on January 2, 2020.
 
 
 
 
-Kumari & Kline           Expires January 3, 2020                [Page 1]
+Kumari & Kline           Expires January 2, 2020                [Page 1]
 
 Internet-Draft             DHCP Captive-Portal                 July 2019
 
@@ -67,7 +67,7 @@ Copyright Notice
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -83,18 +83,16 @@ Table of Contents
      2.1.  IPv4 DHCP Option  . . . . . . . . . . . . . . . . . . . .   4
      2.2.  IPv6 DHCP Option  . . . . . . . . . . . . . . . . . . . .   4
      2.3.  The Captive-Portal IPv6 RA Option . . . . . . . . . . . .   5
-   3.  The Captive-Portal Link Relation Type . . . . . . . . . . . .   6
-   4.  Precedence of API URIs  . . . . . . . . . . . . . . . . . . .   6
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
-     5.1.  IETF params Registration  . . . . . . . . . . . . . . . .   6
-       5.1.1.  Registry name: Captive Portal Unrestricted Identifier   6
-       5.1.2.  Registry name: Captive Portal API Link Relation Type    7
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
-   8.  Normative References  . . . . . . . . . . . . . . . . . . . .   8
-   Appendix A.  Changes / Author Notes.  . . . . . . . . . . . . . .   9
+   3.  Precedence of API URIs  . . . . . . . . . . . . . . . . . . .   5
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
+     4.1.  IETF params Registration  . . . . . . . . . . . . . . . .   6
+       4.1.1.  Registry name: Captive Portal Unrestricted Identifier   6
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   7
+   7.  Normative References  . . . . . . . . . . . . . . . . . . . .   7
+   Appendix A.  Changes / Author Notes.  . . . . . . . . . . . . . .   8
    Appendix B.  Changes from RFC 7710  . . . . . . . . . . . . . . .   9
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
 
@@ -107,18 +105,17 @@ Table of Contents
    provide needed functionality because the client will need to know
    when it is behind a captive portal and how to contact it.
 
+   In order to present users with the payment or AUP pages, the captive-
+   portal device has to intercept the user's connections and redirect
+   the user to the captive portal, using methods that are very similar
 
 
 
-
-Kumari & Kline           Expires January 3, 2020                [Page 2]
+Kumari & Kline           Expires January 2, 2020                [Page 2]
 
 Internet-Draft             DHCP Captive-Portal                 July 2019
 
 
-   In order to present users with the payment or AUP pages, the captive-
-   portal device has to intercept the user's connections and redirect
-   the user to the captive portal, using methods that are very similar
    to man-in-the-middle (MITM) attacks.  As increasing focus is placed
    on security, and end nodes adopt a more secure stance, these
    interception techniques will become less effective and/or more
@@ -164,17 +161,17 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    header field ([RFC7231] Section 5.3) containing a field item whose
    content-type is "application/capport+json" to the URL conveyed in the
    "user-portal-url" API key.  When performing such content negotiation
+   ([RFC7231] Section 3.4), captive portals need to keep in mind that
+   such responses might be cached, and therefore SHOULD include an
+   appropriate Vary header field ([RFC7231] Section 7.1.4) or mark them
 
 
 
-Kumari & Kline           Expires January 3, 2020                [Page 3]
+Kumari & Kline           Expires January 2, 2020                [Page 3]
 
 Internet-Draft             DHCP Captive-Portal                 July 2019
 
 
-   ([RFC7231] Section 3.4), captive portals need to keep in mind that
-   such responses might be cached, and therefore SHOULD include an
-   appropriate Vary header field ([RFC7231] Section 7.1.4) or mark them
    explicitly uncacheable (for example, using Cache-Control: no-store
    [RFC7234] Section 5.2.2.3).
 
@@ -191,7 +188,7 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
 
    Networks with no captive portals MAY explicitly indicate this
    condition by using this option with the IANA-assigned URI for this
-   purpose (see Section 5.1.1).  Clients observing the URI value
+   purpose (see Section 4.1.1).  Clients observing the URI value
    "urn:ietf:params:capport-unrestricted" MAY forego time-consuming
    forms of captive portal detection.
 
@@ -215,19 +212,6 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
 
    The format of the IPv6 Captive-Portal DHCP option is shown below.
 
-
-
-
-
-
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 4]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
-
       0                   1                   2                   3
       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -236,6 +220,13 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
       .                      URI (variable length)                    .
       |                              ...                              |
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+Kumari & Kline           Expires January 2, 2020                [Page 4]
+
+Internet-Draft             DHCP Captive-Portal                 July 2019
+
 
    o  option-code: The Captive-Portal DHCPv6Option (103) (two octets)
 
@@ -273,33 +264,7 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
       total option length (including the Type and Length fields) a
       multiple of 8 bytes.
 
-
-
-
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 5]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
-
-3.  The Captive-Portal Link Relation Type
-
-   Some captive portal network deployments may be unable to change, or
-   unwilling to risk changing, the network infrastructure necessary to
-   use any of the above options.  In such deployments, when clear text
-   HTTP intercept and redirection are used, a Link relation header
-   ([RFC8288], Section 3.3) MAY be inserted to convey to a HTTP client
-   (user agent) the associated Captive Portal API URI.
-
-   HTTP user agents MUST ignore this link relation in any context other
-   than when explicitly probing to detect the presence of a captive
-   portal.  Failure to do so could allow an attacker to inject a Captive
-   Portal API URI other than the correct URI for a given network or for
-   networks where there is no captive portal present at all.
-
-4.  Precedence of API URIs
+3.  Precedence of API URIs
 
    A device may learn about Captive Portal API URIs through more than
    one of (or indeed all of) the above options.  It is a network
@@ -309,37 +274,36 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    captive device MUST prioritize URIs learned from network provisioning
    or configuration mechanisms before all other URIs.  Specifically,
    URIs learned via any of the options in Section 2 should take
-   precedence over any URI learned via a mechanism like the one
-   described in Section 3.
+   precedence over any URI learned via some other mechanism, such as a
+   redirect.
+
+
+
+Kumari & Kline           Expires January 2, 2020                [Page 5]
+
+Internet-Draft             DHCP Captive-Portal                 July 2019
+
 
    If the URIs learned via more than one option described in Section 2
    are not all identical, this condition should be logged for the device
    owner or administrator.  URI precedence in this situation is not
    specified by this document.
 
-5.  IANA Considerations
+4.  IANA Considerations
 
    This document requests two new IETF URN protocol parameter
    ([RFC3553]) entries.
 
    Thanks IANA!
 
-5.1.  IETF params Registration
+4.1.  IETF params Registration
 
-5.1.1.  Registry name: Captive Portal Unrestricted Identifier
+4.1.1.  Registry name: Captive Portal Unrestricted Identifier
 
    Registry name: Captive Portal Unrestricted Identifier
 
    URN: urn:ietf:params:capport-unrestricted
 
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 6]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
-
    Specification: RFC TBD (this document)
 
    Repository: RFC TBD (this document)
@@ -347,24 +311,10 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    Index value: Only one value is defined (see URN above).  No hierarchy
    is defined and therefore no sub-namespace registrations are possible.
 
-5.1.2.  Registry name: Captive Portal API Link Relation Type
+5.  Security Considerations
 
-   Registry name: Captive Portal API Link Relation Type
-
-   URN: urn:ietf:params:capport-api
-
-   Specification: RFC TBD (this document)
-
-   Repository: RFC TBD (this document)
-
-   Index value: Only one value is defined (see URN above).  No hierarchy
-   is defined and therefore no sub-namespace registrations are possible.
-
-6.  Security Considerations
-
-   An attacker with the ability to inject DHCP messages, RAs, or HTTP
-   headers into cleartext HTTP communications could include an option or
-   link relation from this document and so force users to contact an
+   An attacker with the ability to inject DHCP messages or RAs could
+   include an option from this document to force users to contact an
    address of his choosing.  As an attacker with this capability could
    simply list himself as the default gateway (and so intercept all the
    victim's traffic); this does not provide them with significantly more
@@ -382,20 +332,20 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    Devices and systems that automatically connect to an open network
    could potentially be tracked using the techniques described in this
    document (forcing the user to continually authenticate, or exposing
+
+
+
+Kumari & Kline           Expires January 2, 2020                [Page 6]
+
+Internet-Draft             DHCP Captive-Portal                 July 2019
+
+
    their browser fingerprint).  However, similar tracking can already be
    performed with the standard captive portal mechanisms, so this
    technique does not give the attackers more capabilities.
 
    Captive portals are increasingly hijacking TLS connections to force
    browsers to talk to the portal.  Providing the portal's URI via a
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 7]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
-
    DHCP or RA option is a cleaner technique, and reduces user
    expectations of being hijacked - this may improve security by making
    users more reluctant to accept TLS hijacking, which can be performed
@@ -414,7 +364,7 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    sand-boxed environment and with a configuration that minimizes
    tracking risks.
 
-7.  Acknowledgements
+6.  Acknowledgements
 
    This document is a -bis of RFC7710.  Thanks to all of the original
    authors (Warren Kumari, Olafur Gudmundsson, Paul Ebersman, Steve
@@ -423,12 +373,12 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
    Also thanks to the CAPPORT WG for all of the discussion and
    improvements.
 
-8.  Normative References
+7.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC2131]  Droms, R., "Dynamic Host Configuration Protocol",
               RFC 2131, DOI 10.17487/RFC2131, March 1997,
@@ -439,18 +389,17 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
               for IPv6 (DHCPv6)", RFC 3315, DOI 10.17487/RFC3315, July
               2003, <https://www.rfc-editor.org/info/rfc3315>.
 
+
+
+Kumari & Kline           Expires January 2, 2020                [Page 7]
+
+Internet-Draft             DHCP Captive-Portal                 July 2019
+
+
    [RFC3553]  Mealling, M., Masinter, L., Hardie, T., and G. Klyne, "An
               IETF URN Sub-namespace for Registered Protocol
               Parameters", BCP 73, RFC 3553, DOI 10.17487/RFC3553, June
               2003, <https://www.rfc-editor.org/info/rfc3553>.
-
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 8]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
 
    [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
               Resource Identifier (URI): Generic Syntax", STD 66,
@@ -459,8 +408,8 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
 
    [RFC4861]  Narten, T., Nordmark, E., Simpson, W., and H. Soliman,
               "Neighbor Discovery for IP version 6 (IPv6)", RFC 4861,
-              DOI 10.17487/RFC4861, September 2007, <https://www.rfc-
-              editor.org/info/rfc4861>.
+              DOI 10.17487/RFC4861, September 2007,
+              <https://www.rfc-editor.org/info/rfc4861>.
 
    [RFC7227]  Hankins, D., Mrugalski, T., Siodelski, M., Jiang, S., and
               S. Krishnan, "Guidelines for Creating New DHCPv6 Options",
@@ -469,8 +418,8 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
 
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
-              DOI 10.17487/RFC7231, June 2014, <https://www.rfc-
-              editor.org/info/rfc7231>.
+              DOI 10.17487/RFC7231, June 2014,
+              <https://www.rfc-editor.org/info/rfc7231>.
 
    [RFC7234]  Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke,
               Ed., "Hypertext Transfer Protocol (HTTP/1.1): Caching",
@@ -483,8 +432,8 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
               December 2015, <https://www.rfc-editor.org/info/rfc7710>.
 
    [RFC8288]  Nottingham, M., "Web Linking", RFC 8288,
-              DOI 10.17487/RFC8288, October 2017, <https://www.rfc-
-              editor.org/info/rfc8288>.
+              DOI 10.17487/RFC8288, October 2017,
+              <https://www.rfc-editor.org/info/rfc8288>.
 
 Appendix A.  Changes / Author Notes.
 
@@ -494,19 +443,20 @@ Appendix A.  Changes / Author Notes.
 
    o  Import of RFC7710.
 
+
+
+
+
+Kumari & Kline           Expires January 2, 2020                [Page 8]
+
+Internet-Draft             DHCP Captive-Portal                 July 2019
+
+
 Appendix B.  Changes from RFC 7710
 
    This document incorporates the following changes from [RFC7710].
 
    1.  Clarify that IP string literals are NOT RECOMMENDED.
-
-
-
-
-Kumari & Kline           Expires January 3, 2020                [Page 9]
-
-Internet-Draft             DHCP Captive-Portal                 July 2019
-
 
    2.  Clarify that the option URI SHOULD be that of the captive portal
        API endpoint.
@@ -517,8 +467,6 @@ Internet-Draft             DHCP Captive-Portal                 July 2019
        of a network configuration error.
 
    5.  Added urn:ietf:params:capport-unrestricted URN.
-
-   6.  Added urn:ietf:params:capport-api URN.
 
 Authors' Addresses
 
@@ -555,9 +503,5 @@ Authors' Addresses
 
 
 
-
-
-
-
-Kumari & Kline           Expires January 3, 2020               [Page 10]
+Kumari & Kline           Expires January 2, 2020                [Page 9]
 ```

--- a/draft-ekwk-capport-rfc7710bis.xml
+++ b/draft-ekwk-capport-rfc7710bis.xml
@@ -254,21 +254,6 @@
       </section>
     </section>
 
-    <section anchor="linkrel" title="The Captive-Portal Link Relation Type">
-      <t>Some captive portal network deployments may be unable to change, or
-      unwilling to risk changing, the network infrastructure necessary to use
-      any of the above options. In such deployments, when clear text HTTP
-      intercept and redirection are used, a Link relation header (<xref
-      target="RFC8288"/>, Section 3.3) MAY be inserted to convey to a HTTP
-      client (user agent) the associated Captive Portal API URI.</t>
-
-      <t>HTTP user agents MUST ignore this link relation in any context other
-      than when explicitly probing to detect the presence of a captive portal.
-      Failure to do so could allow an attacker to inject a Captive Portal API
-      URI other than the correct URI for a given network or for networks where
-      there is no captive portal present at all.</t>
-    </section>
-
     <section anchor="precedence" title="Precedence of API URIs">
       <t>A device may learn about Captive Portal API URIs through more than
       one of (or indeed all of) the above options. It is a network
@@ -278,8 +263,8 @@
       captive device MUST prioritize URIs learned from network provisioning or
       configuration mechanisms before all other URIs. Specifically, URIs
       learned via any of the options in <xref target="option"/> should take
-      precedence over any URI learned via a mechanism like the one described
-      in <xref target="linkrel"/>.</t>
+      precedence over any URI learned via some other mechanism, such as a
+      redirect.</t>
 
       <t>If the URIs learned via more than one option described in <xref
       target="option"/> are not all identical, this condition should be logged
@@ -309,29 +294,13 @@
           hierarchy is defined and therefore no sub-namespace registrations
           are possible.</t>
         </section>
-
-        <section anchor="ietf_params_capport-api"
-                 title="Registry name: Captive Portal API Link Relation Type">
-          <t>Registry name: Captive Portal API Link Relation Type</t>
-
-          <t>URN: urn:ietf:params:capport-api</t>
-
-          <t>Specification: RFC TBD (this document)</t>
-
-          <t>Repository: RFC TBD (this document)</t>
-
-          <t>Index value: Only one value is defined (see URN above). No
-          hierarchy is defined and therefore no sub-namespace registrations
-          are possible.</t>
-        </section>
       </section>
     </section>
 
     <section anchor="security" title="Security Considerations">
-      <t>An attacker with the ability to inject DHCP messages, RAs, or HTTP
-      headers into cleartext HTTP communications could include an option or
-      link relation from this document and so force users to contact an
-      address of his choosing. As an attacker with this capability could
+      <t>An attacker with the ability to inject DHCP messages or RAs
+      could include an option from this document to force users to contact
+      an address of his choosing. As an attacker with this capability could
       simply list himself as the default gateway (and so intercept all the
       victim's traffic); this does not provide them with significantly more
       capabilities, but because this document removes the need for
@@ -434,8 +403,6 @@
           of a network configuration error.</t>
 
           <t>Added urn:ietf:params:capport-unrestricted URN.</t>
-
-          <t>Added urn:ietf:params:capport-api URN.</t>
         </list></t>
     </section>
   </back>


### PR DESCRIPTION
At IETF 106, we discussed removing the link relation. This PR does that.